### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # List external packages here
 # Avoid fixed versions
-PyYAML>=5.4.1,<6
+PyYAML>=5.3.1,<6 # 5.4.1 causes install to break see https://github.com/yaml/pyyaml/issues/724


### PR DESCRIPTION
### Error from 5.4.1: 
```
Collecting PyYAML<6,>=5.4.1 (from be-helpers<1,>=0.1.0->-r requirements.txt (line 6))
  Downloading PyYAML-5.4.1.tar.gz (175 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 540.4 kB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [68 lines of output]
      /tmp/pip-build-env-zph7_yiw/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
      !!
      
              ********************************************************************************
              The license_file parameter is deprecated, use license_files instead.
      
              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************
      
      !!

```

[](https://github.com/yaml/pyyaml/issues/724)